### PR TITLE
refs #4 パラメータの方向のin/outが無視されず、「in T」というクラスができてしまう不具合

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/csharpreverse/reverser/Tool.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/csharpreverse/reverser/Tool.java
@@ -409,6 +409,14 @@ public class Tool {
 	}
 	
 	private static String[] splitNameAndTypeModifier(String type) {
+
+	    type = type.trim();
+        if (type.startsWith("in ")) {
+            type = type.replaceFirst("in ", "").trim();
+        } else if (type.startsWith("out ")) {
+            type = type.replaceFirst("out ", "").trim();
+        }
+
 		String[] split = new String[2];
 		if (type.endsWith("**")) {
 			split[0] = type.substring(0, type.indexOf("**")).trim();


### PR DESCRIPTION
#4
- "in T" "out TResult" などのin/outは予約語のため、"in ", "out "は取り除くよう修正
